### PR TITLE
Bump session manager to 1.1.23

### DIFF
--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -1,9 +1,9 @@
 class AwsSessionManagerPlugin < Formula
   desc "Official Amazon AWS session manager plugin"
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  url "https://s3.amazonaws.com/session-manager-downloads/plugin/1.1.17.0/mac/sessionmanager-bundle.zip"
-  version "1.1.17.0"
-  sha256 "220480e053378567bfee6f27da0269e14cc5051659bb50913d84364a446bf023"
+  url "https://s3.amazonaws.com/session-manager-downloads/plugin/1.1.23.0/mac/sessionmanager-bundle.zip"
+  version "1.1.23.0"
+  sha256 "df6623c8505a07245778f45d24ec9aa0dabbb32939c9e240ff4cc7c2fd38aa44"
 
   depends_on "awscli"
 


### PR DESCRIPTION
This version, I hope, is compatible with ProxyCommand and allows scp.

https://aws.amazon.com/about-aws/whats-new/2019/07/session-manager-launches-tunneling-support-for-ssh-and-scp/