### PR TITLE
Bumping version to 1.1.61.0

### DIFF
--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -1,10 +1,10 @@
 class AwsSessionManagerPlugin < Formula
   desc "Official Amazon AWS session manager plugin"
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  url "https://s3.amazonaws.com/session-manager-downloads/plugin/1.1.54.0/mac/sessionmanager-bundle.zip"
+  url "https://s3.amazonaws.com/session-manager-downloads/plugin/1.1.61.0/mac/sessionmanager-bundle.zip"
 
-  version "1.1.54.0"
-  sha256 "d9b558193370b2ecc0ddba001b6ee974b14b60d4d247851706e26a9811f15349"
+  version "1.1.61.0"
+  sha256 "426615b12b2d7728504ee7896c60fa330534314d6cb64ee8cb3ea0488e7d66e4"
 
   depends_on "awscli"
 


### PR DESCRIPTION
Version 1.1.61.0 is the current latest.

Version | Release date | Details
-- | -- | --
1.1.61.0 | April 17, 2020 | Enhancement: Added ARM                                                    support for Linux and Ubuntu Server.

[Source](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)