### PR TITLE
Fix CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,11 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
-    container:
-      image: homebrew/ubuntu20.04:master
-    env:
-      HOMEBREW_CORE_GIT_REMOTE: ${{github.event.repository.html_url}}
-      HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
+    name: Test MacOS
+    runs-on: macos-latest
     steps:
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+     - name: Set up Homebrew
+       uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Run brew test-bot
-        run: |
-          mkdir ~/bottles
-          cd ~/bottles
-          brew test-bot --only-formulae
+     - name: Test Formula
+       run: brew test-bot

--- a/Formula/aws-session-manager-plugin.rb
+++ b/Formula/aws-session-manager-plugin.rb
@@ -3,7 +3,6 @@ class AwsSessionManagerPlugin < Formula
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
   url "https://s3.amazonaws.com/session-manager-downloads/plugin/1.2.7.0/mac/sessionmanager-bundle.zip"
 
-  version "1.2.7.0"
   sha256 "1cffa8a4d8d2e77cd1f5e531a4d507183f6b64dd73ee50dcebe9ce351f1f6bfb"
 
   depends_on "awscli"


### PR DESCRIPTION
- Fix testing for OSX
- Remove static `version` property that fails linting